### PR TITLE
chore: Fix deprecation warning at goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ builds:
       - -s -w -X "main.Version={{.Tag}}" -X "main.Revision={{.ShortCommit}}"
 
 archives:
-  - format: tar.gz
+  - formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -39,7 +39,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
 
 changelog:
   disable: true


### PR DESCRIPTION
https://goreleaser.com/deprecations/#archivesformat

```
  • setting defaults
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
    • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```

https://github.com/sue445/terraform-version-updater/actions/runs/13286405241/job/37095993395