### PR TITLE
doc: Fix error when `go install github.com/sue445/terraform-version-updater@latest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Download latest binary from https://github.com/sue445/terraform-version-updater/
 
 ## Build
 ```bash
-go install github.com/sue445/terraform-version-updater@latest
+go install github.com/sue445/terraform-version-updater/cmd/terraform-version-updater@latest
 ```
 
 ## Example


### PR DESCRIPTION
```
$ go install github.com/sue445/terraform-version-updater@latest
go: downloading github.com/sue445/terraform-version-updater v0.1.6
package github.com/sue445/terraform-version-updater is not a main package
```